### PR TITLE
✨ Add nix flake infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ logs
 *.vsix
 hyprls
 hyprls
+result/

--- a/Justfile
+++ b/Justfile
@@ -3,7 +3,8 @@ latestTag := `git describe --tags --abbrev=0 || echo commit:$(git rev-parse --sh
 
 release tag:
 	jq '.version = "{{ tag }}"' < vscode/package.json | sponge vscode/package.json
-	git add vscode/package.json
+	sed -i "s/$(grep 'version' default.nix)/  version = \"{{ tag }}\";/" default.nix
+	git add vscode/package.json default.nix
 	git commit -m "🏷️ Release {{ tag }}"
 	git tag -- v{{ tag }}
 	cd vscode; bun vsce package; bun vsce publish

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,22 @@
+{ pkgs ? (
+    let
+      inherit (builtins) fetchTree fromJSON readFile;
+      inherit ((fromJSON (readFile ./flake.lock)).nodes) nixpkgs gomod2nix;
+    in
+    import (fetchTree nixpkgs.locked) {
+      overlays = [
+        (import "${fetchTree gomod2nix.locked}/overlay.nix")
+      ];
+    }
+  )
+, buildGoApplication ? pkgs.buildGoApplication
+}:
+
+buildGoApplication {
+  pname = "hyprls";
+  version = "0.2.0";
+  pwd = ./.;
+  src = ./.;
+  modules = ./gomod2nix.toml;
+  checkFlags = ["-skip=TestHighLevelParse"]; # not yet implemented
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,85 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gomod2nix": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1717050755,
+        "narHash": "sha256-C9IEHABulv2zEDFA+Bf0E1nmfN4y6MIUe5eM2RCrDC0=",
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "rev": "31b6d2e40b36456e792cd6cf50d5a8ddd2fa59a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1720957393,
+        "narHash": "sha256-oedh2RwpjEa+TNxhg5Je9Ch6d3W1NKi7DbRO1ziHemA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "693bc46d169f5af9c992095736e82c3488bf7dbb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "gomod2nix": "gomod2nix",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  description = "A LSP server for Hyprland config files";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    gomod2nix.url = "github:nix-community/gomod2nix";
+    gomod2nix.inputs.nixpkgs.follows = "nixpkgs";
+    gomod2nix.inputs.flake-utils.follows = "flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, gomod2nix }:
+    (flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+
+          # The current default sdk for macOS fails to compile go projects, so we use a newer one for now.
+          # This has no effect on other platforms.
+          callPackage = pkgs.darwin.apple_sdk_11_0.callPackage or pkgs.callPackage;
+        in
+        {
+          packages.default = callPackage ./. {
+            inherit (gomod2nix.legacyPackages.${system}) buildGoApplication;
+          };
+          devShells.default = callPackage ./shell.nix {
+            inherit (gomod2nix.legacyPackages.${system}) mkGoEnv gomod2nix;
+          };
+        })
+    );
+}

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -1,0 +1,63 @@
+schema = 3
+
+[mod]
+  [mod."github.com/MakeNowJust/heredoc"]
+    version = "v1.0.0"
+    hash = "sha256-8hKERAVV1Pew84kc9GkW23dcO8uIUx/+tJQLi+oPwqE="
+  [mod."github.com/PuerkitoBio/goquery"]
+    version = "v1.5.1"
+    hash = "sha256-GqxIdhuN1L3enT8pNlWm+rmkdN5uMfF8TfpxhAHhEDQ="
+  [mod."github.com/anaskhan96/soup"]
+    version = "v1.2.5"
+    hash = "sha256-t8yCyK2y7x2qaI/3Yw16q3zVFqu+3acLcPgTr1MIKWg="
+  [mod."github.com/andybalholm/cascadia"]
+    version = "v1.1.0"
+    hash = "sha256-mL40/Q9iXBzzMHwMomqTOpp9rnI/MRsufb5cIU1MMPg="
+  [mod."github.com/davecgh/go-spew"]
+    version = "v1.1.1"
+    hash = "sha256-nhzSUrE1fCkN0+RL04N4h8jWmRFPPPWbCuDc7Ss0akI="
+  [mod."github.com/evorts/html-to-markdown"]
+    version = "v0.0.10"
+    hash = "sha256-JV/v/rbKakJuSUTcOtRabeB0EzZRL+Nw5fYW5DRMxPg="
+  [mod."github.com/mazznoer/csscolorparser"]
+    version = "v0.1.3"
+    hash = "sha256-v8WyeQKL+SkOar4nftTFrvyitVjFPZRoVeuksp8OnMk="
+  [mod."github.com/metal3d/go-slugify"]
+    version = "v0.0.0-20160607203414-7ac2014b2f23"
+    hash = "sha256-vAfoTRKnDwLi7xLmFXP88auA8ZLJ8W6sLIj569hlkTk="
+  [mod."github.com/segmentio/asm"]
+    version = "v1.2.0"
+    hash = "sha256-zbNuKxNrUDUc6IlmRQNuJQzVe5Ol/mqp7srDg9IMMqs="
+  [mod."github.com/segmentio/encoding"]
+    version = "v0.4.0"
+    hash = "sha256-4pWI9eTZRRDP9kO8rG6vbLCtBVVRLtbCJKd0Z2+8JoU="
+  [mod."github.com/yuin/goldmark"]
+    version = "v1.7.1"
+    hash = "sha256-3EUgwoZRRs2jNBWSbB0DGNmfBvx7CeAgEwyUdaRaeR4="
+  [mod."go.lsp.dev/jsonrpc2"]
+    version = "v0.10.0"
+    hash = "sha256-RbRsMYVBLR7ZDHHGMooycrkdbIauMXkQjVOGP7ggSgM="
+  [mod."go.lsp.dev/pkg"]
+    version = "v0.0.0-20210717090340-384b27a52fb2"
+    hash = "sha256-TxS0Iqe1wbIaFe7MWZJRQdgqhKE8i8CggaGSV9zU1Vg="
+  [mod."go.lsp.dev/protocol"]
+    version = "v0.12.0"
+    hash = "sha256-rZgWIQpHHeYpJL8kiHJ21m1BHXAcr+4Xv2Yh9RNw3s4="
+  [mod."go.lsp.dev/uri"]
+    version = "v0.3.0"
+    hash = "sha256-jGP0N7Gf+bql5oJraUo33sXqWg7AKOTj0D8b4paV4dc="
+  [mod."go.uber.org/multierr"]
+    version = "v1.11.0"
+    hash = "sha256-Lb6rHHfR62Ozg2j2JZy3MKOMKdsfzd1IYTR57r3Mhp0="
+  [mod."go.uber.org/zap"]
+    version = "v1.27.0"
+    hash = "sha256-8655KDrulc4Das3VRduO9MjCn8ZYD5WkULjCvruaYsU="
+  [mod."golang.org/x/net"]
+    version = "v0.0.0-20200320220750-118fecf932d8"
+    hash = "sha256-YdLYymyqwWmiBR6QJdgvOq+QbQvmAh2VAk4KnB+GZAQ="
+  [mod."golang.org/x/sys"]
+    version = "v0.19.0"
+    hash = "sha256-cmuL31TYLJmDm/fDnI2Sn0wB88cpdOHV1+urorsJWx4="
+  [mod."golang.org/x/text"]
+    version = "v0.3.0"
+    hash = "sha256-0FFbaxF1ZuAQF3sCcA85e8MO6prFeHint36inija4NY="

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,29 @@
+{ pkgs ? (
+    let
+      inherit (builtins) fetchTree fromJSON readFile;
+      inherit ((fromJSON (readFile ./flake.lock)).nodes) nixpkgs gomod2nix;
+    in
+    import (fetchTree nixpkgs.locked) {
+      overlays = [
+        (import "${fetchTree gomod2nix.locked}/overlay.nix")
+      ];
+    }
+  )
+, mkGoEnv ? pkgs.mkGoEnv
+, gomod2nix ? pkgs.gomod2nix
+}:
+
+let
+  goEnv = mkGoEnv { pwd = ./.; };
+in
+pkgs.mkShell {
+  packages = [
+    goEnv
+    gomod2nix
+  ] ++ (with pkgs; [
+    just
+    jq
+    moreutils # sponge
+    bun
+  ]);
+}


### PR DESCRIPTION
Adding nix infrastructure as suggested in https://github.com/hyprland-community/hyprls/issues/12#issuecomment-2233348793.

Added a flake.nix and default.nix to properly build the package, which now can be used with `nix build` or `nix run`. The go modules are handled by [gomod2nix](https://github.com/nix-community/gomod2nix), which can regerenate the gomod2nix.toml with `nix develop` and `gomod2nix regenerate` (if you change anything on the go modules). I've added a line in the justfile that make your release command also change the nix package version, so you don't have to worry about it. I've also added the result dir (the directory of the nix builds) to the gitignore.

The flake itself is locked with a flake.lock and can be updated with `nix flake update`. It's tracking nixos-unstable (the rolling-release branch of NixOS), but it can track the stable version if requested (although you'll have to change the url from time to time to update the stable version eg. 24.05 will be 24.11 in the next release).

Also added a shell.nix to handle `nix develop`, this pulls all the tooling for development and also gomod2nix. You can add more packages inside the `pkgs.mkShell` to enhance the development environment. I've added all the basic tools I've found in your justfile.