### PR TITLE
Update Justfile ensure ~/.local/bin during install

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -29,6 +29,7 @@ build-debug:
 
 install:
 	just build
+	mkdir -p ~/.local/bin
 	cp hyprls ~/.local/bin/hyprls
 
 pull-wiki:


### PR DESCRIPTION
My fresh Arch install did not have .local/bin. I guess it wouldn't hurt to ensure its creation.