### PR TITLE
Create release-bin.yml

### DIFF
--- a/.github/workflows/release-bin.yml
+++ b/.github/workflows/release-bin.yml
@@ -1,0 +1,32 @@
+name: Release pre-built binaries for new tag
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: go-setup
+        uses: actions/setup-go@v5
+
+      - name: go-build
+        run: go build -o hyprls cmd/hyprls/main.go
+
+      - name: zip-artifacts
+        run: zip hyprls.zip hyprls
+
+      - name: deploy-binaries
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: hyprls.zip
+          token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Add an action to automatically build and publish binaries on new `git tag`, closes #30 